### PR TITLE
fix:修改动态import引入错误问题

### DIFF
--- a/src/CodeMirror.js
+++ b/src/CodeMirror.js
@@ -51,7 +51,7 @@ export default class ReactCodeMirror extends Component {
     if (typeof options === 'object') {
       const mode = CodeMirror.findModeByName(options.mode);
       if (mode && mode.mode) {
-        await import(`codemirror/mode/${mode.mode}/${mode.mode}.js`);
+        await require(`codemirror/mode/${mode.mode}/${mode.mode}.js`);
       }
       if (mode) {
         options.mode = mode.mime;


### PR DESCRIPTION
在直接使用的时候产生报错的原因是：

`CodeMirror.js`中的一段代码造成的：

```js
await import(`codemirror/mode/${mode.mode}/${mode.mode}.js`);
```
因为babel无法直接编译动态`import`造成的，所以直接将这里的`import`改成`require`形式引入来规避这个语法错误问题。