### PR TITLE
Remove duplicate onCursorActivity type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -89,10 +89,6 @@ export interface IReactCodemirror extends IDOMEvent {
    * */
   onOverwriteToggle?: (instance: CodeMirror.Editor, overwrite: boolean) => void;
   /**
-   * Fired whenever the cursor or selection in this document changes.
-   * */
-  onCursorActivity?(instance: CodeMirror.Editor): void;
-  /**
    * Will be fired when the line object is deleted. A line object is associated with the start of the line.
    * Mostly useful when you need to find out when your gutter markers on a given line are removed.
    * */


### PR DESCRIPTION
Removes duplicate `onCursorActivity` declaration in `typings/index.t.ts`. Duplicate declaration causes error in Typescript compiler.

Closes #45 