### PR TITLE
Add prop to optionally disable lazy loading language modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const code = 'const a = 0;';
 />
 ```
 
-requiring codemirror resources, This is often the case when specifying certain language modes and themes. Just set the mode, the language resources will automatically lazy loading.
+requiring codemirror resources. This is often done when specifying certain language modes and themes. Language resources do not need to be imported, just set the mode and they will be automatically lazy loaded.
 
 ```jsx
 import CodeMirror from '@uiw/react-codemirror';
@@ -63,6 +63,29 @@ const code = 'const a = 0;';
     tabSize: 2,
     keyMap: 'sublime',
     mode: 'jsx',
+  }}
+/>
+```
+
+If you do not want to lazy load the language resources, you can set the prop `lazyLoadMode` to `false`. You will need to load the language resources yourself in this case.
+
+```jsx
+import CodeMirror from '@uiw/react-codemirror';
+import 'codemirror/keymap/sublime';
+import 'codemirror/theme/monokai.css';
+// Manually loading the language resources here
+import 'codemirror/mode/javascript/javascript';
+
+const code = 'console.log("hello world!");';
+
+<CodeMirror
+  value={code}
+  lazyLoadMode={false}
+  options={{
+    theme: 'monokai',
+    tabSize: 2,
+    keyMap: 'sublime',
+    mode: 'js',
   }}
 />
 ```
@@ -94,6 +117,7 @@ const code = 'const a = 0;';
 - `width` width of editor. Defaults to `100%`.
 - `height` height of editor. Defaults to `100%`.
 - `value` value of the auto created model in the editor.
+- `lazyLoadMode` should the mode by automatically lazy loaded. If this is set to false you will need to load the mode yourself. Defaults to true.
 - `options` refer to [codemirror options](https://codemirror.net/doc/manual.html#config).
 
 ## Props Events

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const defaultOptions = {
 }
 
 function ReactCodeMirror(props = {}, ref) {
-  const { options = {}, value = '', width = '100%', height = '100%'  } = props;
+  const { options = {}, value = '', width = '100%', height = '100%', lazyLoadMode = true } = props;
   const [editor, setEditor] = useState();
   const textareaRef = useRef();
   const lastestProps = useRef(props);
@@ -44,7 +44,7 @@ function ReactCodeMirror(props = {}, ref) {
   async function setOptions(instance, opt = {}) {
     if (typeof opt === 'object' && window) {
       const mode = CodeMirror.findModeByName(opt.mode || '');
-      if (mode && mode.mode) {
+      if (lazyLoadMode && mode && mode.mode) {
         await import(`codemirror/mode/${mode.mode}/${mode.mode}.js`);
       }
       if (mode) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -24,6 +24,10 @@ export interface IReactCodemirror extends IDOMEvent {
    */
   height?: any;
   /**
+   * should modes be loaded dynamically.  Defaults to true.
+   */
+  lazyLoadMode?: boolean;
+  /**
    * refer to codemirror options.
    */
   options?: CodeMirror.EditorConfiguration;


### PR DESCRIPTION
Hey, thanks for the hard work maintaining this project, it's been super helpful to me so far!

In my set up it doesn't make sense to dynamically load the language resources (modes) at runtime.  I want to have a complete bundle that can be delivered without the need for further network requests.

For this I've added an optional prop, `lazyLoadMode`.  This prop is `true` by default, and if it is `true` nothing changes.  If the prop is `false`, the language resources will not be automatically downloaded and need to be downloaded manually.

The heart of the change is in `src/index.js` line 47.
```diff
-      if (mode && mode.mode) {
+      if (lazyLoadMode && mode && mode.mode) {
```

Just to reiterate, since this prop is `true` by default, this is not a breaking change!

I've updated the types to add this prop, and I've updated the readme to give a quick example of how it can be used.

If there is anything else which needs to be done or anything I can do to assist the project, please feel free to let me know!  Thanks for checking this out

- Nick

