### PR TITLE
Also use highlight style

### DIFF
--- a/src/useCodeMirror.ts
+++ b/src/useCodeMirror.ts
@@ -3,7 +3,7 @@ import { basicSetup as defaultBasicSetup } from '@codemirror/basic-setup';
 import { EditorState, StateEffect } from '@codemirror/state';
 import { indentWithTab as defaultIndentWithTab } from '@codemirror/commands';
 import { EditorView, keymap, ViewUpdate, placeholder as extendPlaceholder } from '@codemirror/view';
-import { oneDarkTheme } from '@codemirror/theme-one-dark';
+import { oneDark } from '@codemirror/theme-one-dark';
 import { ReactCodeMirrorProps } from './';
 import { defaultLightThemeOption } from './theme/light';
 
@@ -69,7 +69,7 @@ export function useCodeMirror(props: UseCodeMirror) {
       getExtensions.push(defaultLightThemeOption);
       break;
     case 'dark':
-      getExtensions.push(oneDarkTheme);
+      getExtensions.push(oneDark);
       break;
     default:
       getExtensions.push(theme);


### PR DESCRIPTION
Currently the syntax highlighting is broken with `theme="dark"`:

![Screen Shot 2022-01-02 at 15 44 38](https://user-images.githubusercontent.com/1935696/147879437-24c48905-c918-4586-b9db-86eef08c0758.png)

It should instead look like this:

![Screen Shot 2022-01-02 at 15 44 04](https://user-images.githubusercontent.com/1935696/147879455-77e061a5-a0f8-4821-bcbe-3ea90aca6ef0.png)

The reason is that the exports in `@codemirror/theme-one-dark` consist of two variables in an array, which
makes up the extension:

https://github.com/codemirror/theme-one-dark/blob/3f6f4e7ec22588df0e8c2777d8ce92889ce811b6/src/one-dark.ts#L134