### PR TITLE
fix: Add type checking to value

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -123,6 +123,11 @@ const ReactCodeMirror = React.forwardRef<ReactCodeMirrorRef, ReactCodeMirrorProp
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // check type of value
+  if (typeof value !== 'string') {
+    throw new Error(`value must be typeof string but got ${typeof value}`);
+  }
+
   const defaultClassNames = typeof theme === 'string' ? `cm-theme-${theme}` : 'cm-theme';
   return <div ref={editor} className={`${defaultClassNames}${className ? ` ${className}` : ''}`} {...other}></div>;
 });


### PR DESCRIPTION
I found that if the value is typeof number, the whole page will block and can't be recovery by refresh, all I can do is only close the blocked page and reopen a new page.

I know this library is based on TypeScript, type error will be found in TypeScript's build-time, but it will be better to check value's type manually and throw error let those who using original JavaScript know what problem was happened.