### PR TITLE
Fix custom theme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ export default function App() {
 ## Using custom theme
 
 ```jsx
-import { oneDarkTheme } from '@codemirror/theme-one-dark';
+import { oneDark } from '@codemirror/theme-one-dark';
 import CodeMirror from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';
 
@@ -176,7 +176,7 @@ export default function App() {
     <CodeMirror
       value="console.log('hello world!');"
       height="100%"
-      theme={oneDarkTheme}
+      theme={oneDark}
       extensions={[javascript({ jsx: true })]}
       onChange={(value, viewUpdate) => {
         console.log('value:', value);


### PR DESCRIPTION
The exports in `@codemirror/theme-one-dark` consist of two variables in an array, which
makes up the extension:

https://github.com/codemirror/theme-one-dark/blob/3f6f4e7ec22588df0e8c2777d8ce92889ce811b6/src/one-dark.ts#L134

Previous PR: https://github.com/uiwjs/react-codemirror/pull/241

cc @arvigeus