### PR TITLE
fix: Avoid react warning for wrong returns from useEffect.

### DIFF
--- a/src/useCodeMirror.ts
+++ b/src/useCodeMirror.ts
@@ -115,7 +115,11 @@ export function useCodeMirror(props: UseCodeMirror) {
     [view],
   );
 
-  useEffect(() => autoFocus && view && (view.focus() as any), [autoFocus, view]);
+  useEffect(() => {
+    if (autoFocus && view) {
+      view.focus();
+    }
+  }, [autoFocus, view]);
 
   useEffect(() => {
     const currentValue = view ? view.state.doc.toString() : '';


### PR DESCRIPTION
Avoid react warning "An effect function must not return anything besides a function..." for returns non-function result.