### PR TITLE
Fix Copy to Clipboard Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ CodeMirror component for React. Demo Preview: [@uiwjs.github.io/react-codemirror
 
 ## Install
 
+**Not dependent on uiw.**
+
 ```bash
-# Not dependent on uiw.
 npm install @uiw/react-codemirror --save
 ```
 


### PR DESCRIPTION
Comment was being copied along with the command. Removed the comment from the code block