### PR TITLE
fix(core): add missing attributes to reconfigure useEffect

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -43,14 +43,15 @@ import CodeMirror from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';
 
 function App() {
+  const onChange = React.useCallback((value, viewUpdate) => {
+    console.log('value:', value);
+  }, []);
   return (
     <CodeMirror
       value="console.log('hello world!');"
       height="200px"
       extensions={[javascript({ jsx: true })]}
-      onChange={(value, viewUpdate) => {
-        console.log('value:', value);
-      }}
+      onChange={onChange}
     />
   );
 }
@@ -79,9 +80,6 @@ export default function App() {
       value={goLang}
       height="200px"
       extensions={[StreamLanguage.define(go)]}
-      onChange={(value, viewUpdate) => {
-        console.log('value:', value);
-      }}
     />
   );
 }
@@ -208,15 +206,16 @@ const myTheme = createTheme({
 });
 
 export default function App() {
+  const onChange = React.useCallback((value, viewUpdate) => {
+    console.log('value:', value);
+  }, []);
   return (
     <CodeMirror
       value="console.log('hello world!');"
       height="200px"
       theme={myTheme}
       extensions={[javascript({ jsx: true })]}
-      onChange={(value, viewUpdate) => {
-        console.log('value:', value);
-      }}
+      onChange={onChange}
     />
   );
 }

--- a/core/src/useCodeMirror.ts
+++ b/core/src/useCodeMirror.ts
@@ -145,15 +145,6 @@ export function useCodeMirror(props: UseCodeMirror) {
   }, [autoFocus, view]);
 
   useEffect(() => {
-    const currentValue = view ? view.state.doc.toString() : '';
-    if (view && value !== currentValue) {
-      view.dispatch({
-        changes: { from: 0, to: currentValue.length, insert: value || '' },
-      });
-    }
-  }, [value, view]);
-
-  useEffect(() => {
     if (view) {
       view.dispatch({ effects: StateEffect.reconfigure.of(getExtensions) });
     }
@@ -165,13 +156,25 @@ export function useCodeMirror(props: UseCodeMirror) {
     minHeight,
     maxHeight,
     width,
-    placeholderStr,
     minWidth,
     maxWidth,
+    placeholderStr,
     editable,
+    readOnly,
     defaultIndentWithTab,
     defaultBasicSetup,
+    onChange,
+    onUpdate,
   ]);
+
+  useEffect(() => {
+    const currentValue = view ? view.state.doc.toString() : '';
+    if (view && value !== currentValue) {
+      view.dispatch({
+        changes: { from: 0, to: currentValue.length, insert: value || '' },
+      });
+    }
+  }, [value, view]);
 
   return { state, setState, view, setView, container, setContainer };
 }


### PR DESCRIPTION
I was coming across an issue where I switch between several files in my React app.

As the user switches the file they are editing I change the `value` prop, and the `onUpdate` prop. Roughly like this:

```jsx
      const onUpdate = useCallback((viewUpdate) => {
        editorStateChanged(filePath, viewUpdate);
      }, [filePath]);

      <CodeMirror
        value={savedFiles.get(filePath).contents}
        onUpdate={onUpdate}
      />
```
There are two bugs fixed here:

1.  More of the props encoded into `getExtensions` are watched by the `reconfigure` `useEffect`
2. The `reconfigure` `useEffect` is ordered **before** the `value` `useEffect`

What was happening was:
* `value` change detected by `useEffect` and `view.dispatch` is triggered.
* `view`'s `updateListener` is triggered and the **old** `onUpdate` is called with the contents from the **new** file.
* The **new** `onUpdate` function is not detected and onUpdate is therefore always called with the **old** filePath.

What happens now:
* `onUpdate` change is detected by the `reconfigure` `useEffect` - _the old onUpdate can now never be called (as you would expect)_
* the `value` change is detected and dispatched through to the **new** onUpdate

I need to refactor my app to make use of `useCodeMirror` directly anyway - so that I can store `EditorState` objects for each file. But I wanted to publish these fixes even though I can technically work around them by not needing `reconfigure` (because I'll be separating the EditorState objects).

**N.B.** I've changed the docs to recommend `useCallback` as that'll be more important with this change.