### PR TITLE
Proposal: add an option to provide serialized initial state

### DIFF
--- a/core/src/index.tsx
+++ b/core/src/index.tsx
@@ -69,6 +69,13 @@ export interface ReactCodeMirrorProps
    * Originally from the [config of EditorView](https://codemirror.net/6/docs/ref/#view.EditorView.constructor%5Econfig.root)
    */
   root?: ShadowRoot | Document;
+  /**
+   * Create a state from its JSON representation serialized with [toJSON](https://codemirror.net/docs/ref/#state.EditorState.toJSON) function
+   */
+  initialState?: {
+    json: any;
+    fields?: Object<StateField<any>>;
+  };
 }
 
 export interface ReactCodeMirrorRef {
@@ -101,6 +108,7 @@ const ReactCodeMirror = forwardRef<ReactCodeMirrorRef, ReactCodeMirrorProps>((pr
     editable,
     readOnly,
     root,
+    initialState,
     ...other
   } = props;
   const editor = useRef<HTMLDivElement>(null);
@@ -127,6 +135,7 @@ const ReactCodeMirror = forwardRef<ReactCodeMirrorRef, ReactCodeMirrorProps>((pr
     onCreateEditor,
     onUpdate,
     extensions,
+    initialState,
   });
 
   useImperativeHandle(ref, () => ({ editor: editor.current, state: state, view: view }), [

--- a/core/src/useCodeMirror.ts
+++ b/core/src/useCodeMirror.ts
@@ -34,6 +34,7 @@ export function useCodeMirror(props: UseCodeMirror) {
     indentWithTab: defaultIndentWithTab = true,
     basicSetup: defaultBasicSetup = true,
     root,
+    initialState,
   } = props;
   const [container, setContainer] = useState<HTMLDivElement>();
   const [view, setView] = useState<EditorView>();
@@ -109,11 +110,14 @@ export function useCodeMirror(props: UseCodeMirror) {
 
   useEffect(() => {
     if (container && !state) {
-      const stateCurrent = EditorState.create({
+      const config = {
         doc: value,
         selection,
         extensions: getExtensions,
-      });
+      };
+      const stateCurrent = initialState
+        ? EditorState.fromJSON(initialState.json, config, initialState.fields)
+        : EditorState.create(config);
       setState(stateCurrent);
       if (!view) {
         const viewCurrent = new EditorView({


### PR DESCRIPTION
Thanks for the great library!

What do you think about adding the way to provide `initialState` property that can be used to initialize the state with [fromJSON](https://codemirror.net/docs/ref/#state.EditorState^fromJSON) function instead of creating it from scratch? This can be helpful to save editor's state with toJSON and restore it when page reloads or component is recreated. 