### PR TITLE
Resolve Phantom Dependency problems

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -36,6 +36,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.6",
+    "@codemirror/commands": "^6.1.0",
+    "@codemirror/state": "^6.1.1",
     "@codemirror/theme-one-dark": "^6.0.0",
     "@uiw/codemirror-extensions-basic-setup": "4.12.0",
     "codemirror": "^6.0.0"


### PR DESCRIPTION
I'm having two issues related Phantom Dependency in Yarn berry:

```
✘ [ERROR] Could not resolve "@codemirror/state"

    ../../node_modules/.store/@uiw-react-codemirror-virtual-d135f79218/node_modules/@uiw/react-codemirror/esm/useCodeMirror.js:2:41:
      2 │ import { EditorState, StateEffect } from '@codemirror/state';
        ╵                                          ~~~~~~~~~~~~~~~~~~~

  You can mark the path "@codemirror/state" as external to exclude it from the bundle, which will
  remove this error.

✘ [ERROR] Could not resolve "@codemirror/commands"

    ../../node_modules/.store/@uiw-react-codemirror-virtual-d135f79218/node_modules/@uiw/react-codemirror/esm/useCodeMirror.js:3:30:
      3 │ import { indentWithTab } from '@codemirror/commands';
        ╵                               ~~~~~~~~~~~~~~~~~~~~~~

  You can mark the path "@codemirror/commands" as external to exclude it from the bundle, which will
  remove this error.
```

- In [`HEAD/core/src/useCodeMirror.ts#L2`](https://github.com/uiwjs/react-codemirror/blob/5ce66e/core/src/useCodeMirror.ts#L2) referring `@codemirror/state` but the package isn't included in the `package.json`.
- In [`HEAD/core/src/useCodeMirror.ts#L3`](https://github.com/uiwjs/react-codemirror/blob/5ce66e/core/src/useCodeMirror.ts#L3) referring `@codemirror/commands` but the package isn't included in the `package.json`.

---

Yarn berry is a package manager that blocks [phantom dependency](https://rushjs.io/pages/advanced/phantom_deps/) issues. 

- For npm or yarn classic users, this is a problem you won't run into
- if you're using a Yarn berry(v2~) that completely blocks Phantom dependencies, you can't avoid it

If possible, I would like to upgrade to a version that fixes this problem and use it.. 🥺 