### PR TITLE
Highlight components tag names with green

### DIFF
--- a/themes/vscode/src/index.ts
+++ b/themes/vscode/src/index.ts
@@ -23,7 +23,7 @@ export function vscodeDarkInit(options?: CreateThemeOptions) {
     },
     styles: [
       {
-        tag: [t.keyword, t.operatorKeyword, t.modifier, t.color, t.constant(t.name), t.standard(t.name), t.tagName, t.special(t.brace), t.atom, t.bool, t.special(t.variableName)],
+        tag: [t.keyword, t.operatorKeyword, t.modifier, t.color, t.constant(t.name), t.standard(t.name), t.standard(t.tagName), t.special(t.brace), t.atom, t.bool, t.special(t.variableName)],
         color: '#569cd6',
       },
       {
@@ -36,7 +36,7 @@ export function vscodeDarkInit(options?: CreateThemeOptions) {
       },
       { tag: t.heading, fontWeight: 'bold', color: '#9cdcfe' },
       {
-        tag: [t.typeName, t.className, t.number, t.changed, t.annotation, t.self, t.namespace],
+        tag: [t.typeName, t.className, t.tagName, t.number, t.changed, t.annotation, t.self, t.namespace],
         color: '#4ec9b0',
       },
       {


### PR DESCRIPTION
Hi @jaywcjlove 👋 Hope you're well!

Just wanted to do a quick PR to add the correct highlighting for JSX component tags, since `@lezer/javascript@>=1.1.0` supports it:

- https://github.com/codemirror/dev/issues/956
- https://github.com/lezer-parser/javascript/releases/tag/1.1.0

VS Code highlights React components with green

**VS Code**

![Screenshot 2022-11-17 at 15 00 04](https://user-images.githubusercontent.com/1935696/202466856-c73c975b-c83c-47ce-a501-5ce57b302723.png)

**Theme Before**

![Screenshot 2022-12-09 at 19 38 41](https://user-images.githubusercontent.com/1935696/206771332-2030285b-d8a7-47ad-a7d3-a6c39f030578.png)


**Theme After**

![Screenshot 2022-12-09 at 19 37 49](https://user-images.githubusercontent.com/1935696/206771295-ad01371c-8565-4b5f-930c-98f5c6488d00.png)

