### PR TITLE
Remove v3 doc preview given that we're already on v4

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -16,8 +16,6 @@
 
 CodeMirror component for React. Demo Preview: [@uiwjs.github.io/react-codemirror](https://uiwjs.github.io/react-codemirror/)
 
-> ⚠️ The [`v3`](https://raw.githack.com/uiwjs/react-codemirror/doc3/index.html) version document preview is [here](https://raw.githack.com/uiwjs/react-codemirror/doc3/index.html).
-
 <!--rehype:style=border-left: 8px solid #ffe564;background-color: #ffe56440;padding: 12px 16px;-->
 
 **Features:**


### PR DESCRIPTION
Apologies if I'm misunderstanding something, but it seems like the doc linked at the top of the README is actually out of date, given that `react-codemirror` is already on version 4.xxxx. This confused me for a bit so to avoid anyone else having the same confusion I propose the link be removed (or otherwise reworded). 