### PR TITLE
Prevent `onChange` handler from being fired when `value` property is changed from the outside

### DIFF
--- a/core/src/__tests__/index.test.tsx
+++ b/core/src/__tests__/index.test.tsx
@@ -85,3 +85,10 @@ it('CodeMirror editable', async () => {
   expect(text.className).toEqual('cm-content');
   expect(text.tagName).toEqual('DIV');
 });
+
+it("CodeMirror doesn't echo changes", async () => {
+  const handleChange = jest.fn();
+  const { rerender } = render(<CodeMirror value="value a" onChange={handleChange} />);
+  rerender(<CodeMirror value="value b" onChange={handleChange} />);
+  expect(handleChange).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
Do not fire `onChange` handler when codemirror's value is changed from outside (this is how ordinary inputs work). Usually it doesn't matter but when CM is used with async apis it can lead to cycling changes of text

Consider the following example ([sandbox](https://codesandbox.io/s/objective-satoshi-strbtj?file=/src/App.js)):
```js
export default function App() {
  const [v, sv] = useState("test");
  return (
    <>
      <input
        value={v}
        onChange={(e) => {
          console.log("input: onChange");
          sv(e.target.value);
        }}
      />
      <CodeMirror
        value={v}
        onChange={(x) => {
          console.log("CodeMirror: onChange");
          sv(x);
        }}
      />
    </>
  );
}

```


Here input field and CodeMirror are bound to one state. 

1. When I edit CodeMirror, the input's onChange has not fired and the console output is 
```
> CodeMirror: onChange
```
2. But when I edit input, both onChange handlers fire:
```
> input: onChange
> CodeMirror: onChange
```
