### PR TITLE
docs: fix indentWithTab prop description

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -397,7 +397,8 @@ export interface ReactCodeMirrorProps
    */
   readOnly?: boolean;
   /**
-   * Whether to optional basicSetup by default
+   * Controls whether pressing the `Tab` key inserts a tab character and indents the text (`true`) 
+   * or behaves according to the browser's default behavior (`false`).
    * @default true
    */
   indentWithTab?: boolean;

--- a/core/src/index.tsx
+++ b/core/src/index.tsx
@@ -45,7 +45,8 @@ export interface ReactCodeMirrorProps
    */
   readOnly?: boolean;
   /**
-   * Whether to optional basicSetup by default
+   * Controls whether pressing the `Tab` key inserts a tab character and indents the text (`true`) 
+   * or behaves according to the browser's default behavior (`false`).
    * @default true
    */
   indentWithTab?: boolean;


### PR DESCRIPTION
## Fix indentWithTab prop description

### Description

The `indentWithTab` prop description in the `ReactCodeMirrorProps` interface was updated to accurately reflect its behavior. 

The description for `indentWithTab` seems to be incorrect, as it duplicated the description of the `basicSetup` prop

### Changes Made
- Updated the `indentWithTab` prop description to: 

  ```ts
  Controls whether pressing the `Tab` key inserts a tab character and indents the text (`true`) 
  or behaves according to the browser's default behavior (`false`).
  ```