### PR TITLE
remove `clike` import

### DIFF
--- a/extensions/langs/src/index.ts
+++ b/extensions/langs/src/index.ts
@@ -30,7 +30,6 @@ import { asciiArmor } from '@codemirror/legacy-modes/mode/asciiarmor';
 import { asterisk } from '@codemirror/legacy-modes/mode/asterisk';
 import { brainfuck } from '@codemirror/legacy-modes/mode/brainfuck';
 import {
-  clike,
   c,
   scala,
   kotlin,


### PR DESCRIPTION
When I try to build my project with extensions-langs with Vite and TypeScript, it fails.

```
/V/S/r/n/web ❯❯❯  pnpm run build                                                                                                                                                                                            master ✱

> web@0.0.0 build /Volumes/SN570/repos/ntoj/web
> tsc && vite build

node_modules/.pnpm/@uiw+codemirror-extensions-langs@4.21.12_@codemirror+autocomplete@6.8.1_@codemirror+language-_ek6k5ykpbfm47cmo3hp4vptutq/node_modules/@uiw/codemirror-extensions-langs/src/index.ts:33:3 - error TS6133: 'clike' is declared but its value is never read.

33   clike,
     ~~~~~


Found 1 error in node_modules/.pnpm/@uiw+codemirror-extensions-langs@4.21.12_@codemirror+autocomplete@6.8.1_@codemirror+language-_ek6k5ykpbfm47cmo3hp4vptutq/node_modules/@uiw/codemirror-extensions-langs/src/index.ts:33

 ELIFECYCLE  Command failed with exit code 2.

```