### PR TITLE
Fix double highlighting selection when using drawSelection.

### DIFF
--- a/themes/theme/src/index.tsx
+++ b/themes/theme/src/index.tsx
@@ -95,7 +95,7 @@ export const createTheme = ({ theme, settings = {}, styles = [] }: CreateThemeOp
 
   if (settings.selection) {
     themeOptions[
-      '&.cm-focused .cm-selectionBackground, &.cm-focused .cm-line::selection, & .cm-selectionLayer .cm-selectionBackground, .cm-content ::selection'
+      '&.cm-focused .cm-selectionBackground, & .cm-line::selection, & .cm-selectionLayer .cm-selectionBackground, .cm-content ::selection'
     ] = {
       background: settings.selection + ' !important',
     };


### PR DESCRIPTION
When you use the drawSelection() extension, it hides the current selection through:
```
& .cm-line ::selection {
    background-color: transparent !important;
}
```

However, we were styling selections using:
```
&.cm-focused .cm-line ::selection {
    background-color: <some background color> !important;
}
```

Since our style is more selective, it takes precedence over the original style that was supposed to hide the current selection. As a result, if you use drawSelection(), the selection would be highlighted twice, once through ```.cm-selectionBackground``` and once through ```.cm-line::selection```.