### PR TITLE
Add background image option to createTheme()

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -288,6 +288,7 @@ const myTheme = createTheme({
   theme: 'light',
   settings: {
     background: '#ffffff',
+    backgroundImage: '',
     foreground: '#75baff',
     caret: '#5d00ff',
     selection: '#036dd626',

--- a/themes/theme/README.md
+++ b/themes/theme/README.md
@@ -23,6 +23,7 @@ const myTheme = createTheme({
   theme: 'light',
   settings: {
     background: '#ffffff',
+    backgroundImage: '',
     foreground: '#75baff',
     caret: '#5d00ff',
     selection: '#036dd626',
@@ -70,6 +71,7 @@ const myTheme = createTheme({
   theme: 'light',
   settings: {
     background: '#ffffff',
+    backgroundImage: '',
     foreground: '#75baff',
     caret: '#5d00ff',
     selection: '#036dd626',
@@ -297,8 +299,10 @@ export interface CreateThemeOptions {
 }
 declare type Theme = 'light' | 'dark';
 export interface Settings {
-  /** Editor background. */
+  /** Editor background color. */
   background: string;
+  /** Editor background image. */
+  backgroundImage?: string;
   /** Default text color. */
   foreground: string;
   /** Caret color. */

--- a/themes/theme/src/index.tsx
+++ b/themes/theme/src/index.tsx
@@ -19,8 +19,10 @@ export interface CreateThemeOptions {
 type Theme = 'light' | 'dark';
 
 export interface Settings {
-  /** Editor background. */
+  /** Editor background color. */
   background?: string;
+  /** Editor background image. */
+  backgroundImage?: string;
   /** Default text color. */
   foreground?: string;
   /** Caret color. */
@@ -50,6 +52,9 @@ export const createTheme = ({ theme, settings = {}, styles = [] }: CreateThemeOp
   const baseStyle: StyleSpec = {};
   if (settings.background) {
     baseStyle.backgroundColor = settings.background;
+  }
+  if (settings.backgroundImage) {
+    baseStyle.backgroundImage = settings.backgroundImage;
   }
   if (settings.foreground) {
     baseStyle.color = settings.foreground;

--- a/www/src/pages/theme/editor/themeCode.ts
+++ b/www/src/pages/theme/editor/themeCode.ts
@@ -202,6 +202,7 @@ const myTheme = createTheme({
   dark: '${styles.dark}',
   settings: {
     background: '${styles.background}',
+    backgroundImage: '',
     foreground: '${styles.foreground}',
     caret: '${styles.caret}',
     selection: '${styles.selection}',


### PR DESCRIPTION
In all READMEs and the theme editor page, I added `backgroundImage: '',` to show people that the option exists. I don't think we need a background image customizing option on the theme editor page (a text box would look weird next to the color selectors), but let me know if you think otherwise.