### PR TITLE
Remove margin from Example.tsx causing it to be cut off

### DIFF
--- a/www/src/pages/home/Example.tsx
+++ b/www/src/pages/home/Example.tsx
@@ -113,7 +113,6 @@ export default function Example() {
           }}
           style={{
             maxWidth: '995px',
-            margin: '-18px auto 0 auto',
             position: 'relative',
             zIndex: 999,
           }}


### PR DESCRIPTION
The code editor on the home page is being cut off.

Full disclosure, I've only tested this by remving the style through inspector.

## Before
![Before](https://github.com/uiwjs/react-codemirror/assets/6266815/c114924b-8a72-451b-bb65-68b31813eaa8)

## After
![After](https://github.com/uiwjs/react-codemirror/assets/6266815/38fbfb1a-aa92-4981-b1a4-ed6f03f4652d)
