### PR TITLE
Move BackToUp component to the end for improved visibility

### DIFF
--- a/www/src/pages/home/index.tsx
+++ b/www/src/pages/home/index.tsx
@@ -142,7 +142,6 @@ export function Component() {
   const version = VERSION;
   return (
     <div className="wmde-markdown-var">
-      <BackToUp>Top</BackToUp>
       <dark-mode permanent dark="Dark" light="Light" style={{ position: 'fixed', top: 8, left: 8, zIndex: 99 }} />
       <GitHubCorners fixed target="__blank" zIndex={10} href="https://github.com/uiwjs/react-codemirror" />
       <AppHeader>
@@ -187,6 +186,7 @@ export function Component() {
           href="https://www.npmjs.com/package/@uiw/react-codemirror"
         />
       </Footer>
+      <BackToUp>Top</BackToUp>
     </div>
   );
 }


### PR DESCRIPTION
Issue: The visibility of the BackToUp component was affected by the stacking order on the homepage.
![image](https://github.com/uiwjs/react-codemirror/assets/70476337/35d695d3-bc49-46bc-b381-43f09cd0be53)

Solution: Reordered the placement of the BackToUp component to make it  visible element on the page without adjusting z-index property, resolving the visibility issue. This change enhances the user experience by ensuring the BackToUp button is prominently displayed.
![image](https://github.com/uiwjs/react-codemirror/assets/70476337/30578360-782b-4846-8823-0f31d4a82a1f)

This is my first open-source contribution, and I'm open to feedback. Please review, and let me know if there are any additional adjustments required. Thank you!