### PR TITLE
feat(theme): add `console` theme

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -65,6 +65,7 @@ npm install @uiw/react-codemirror --save
 | [`@uiw/codemirror-theme-basic`](https://uiwjs.github.io/react-codemirror/#/theme/data/bbedit)                            | [![npm version](https://img.shields.io/npm/v/@uiw/codemirror-theme-basic.svg)](https://www.npmjs.com/package/@uiw/codemirror-theme-basic) [![NPM Downloads](https://img.shields.io/npm/dm/@uiw/codemirror-theme-basic.svg?style=flat)](https://www.npmjs.com/package/@uiw/codemirror-theme-basic)                                                         |
 | [`@uiw/codemirror-theme-bbedit`](https://uiwjs.github.io/react-codemirror/#/theme/data/bbedit)                           | [![npm version](https://img.shields.io/npm/v/@uiw/codemirror-theme-bbedit.svg)](https://www.npmjs.com/package/@uiw/codemirror-theme-bbedit) [![NPM Downloads](https://img.shields.io/npm/dm/@uiw/codemirror-theme-bbedit.svg?style=flat)](https://www.npmjs.com/package/@uiw/codemirror-theme-bbedit)                                                     |
 | [`@uiw/codemirror-theme-bespin`](https://uiwjs.github.io/react-codemirror/#/theme/data/bespin)                           | [![npm version](https://img.shields.io/npm/v/@uiw/codemirror-theme-bespin.svg)](https://www.npmjs.com/package/@uiw/codemirror-theme-bespin) [![NPM Downloads](https://img.shields.io/npm/dm/@uiw/codemirror-theme-bespin.svg?style=flat)](https://www.npmjs.com/package/@uiw/codemirror-theme-bespin)                                                     |
+| [`@uiw/codemirror-theme-console`](https://uiwjs.github.io/react-codemirror/#/theme/data/console)                         | [![npm version](https://img.shields.io/npm/v/@uiw/codemirror-theme-console.svg)](https://www.npmjs.com/package/@uiw/codemirror-theme-console) [![NPM Downloads](https://img.shields.io/npm/dm/@uiw/codemirror-theme-console.svg?style=flat)](https://www.npmjs.com/package/@uiw/codemirror-theme-console)                                                 |
 | [`@uiw/codemirror-theme-copilot`](https://uiwjs.github.io/react-codemirror/#/theme/data/copilot)                         | [![npm version](https://img.shields.io/npm/v/@uiw/codemirror-theme-copilot.svg)](https://www.npmjs.com/package/@uiw/codemirror-theme-copilot) [![NPM Downloads](https://img.shields.io/npm/dm/@uiw/codemirror-theme-copilot.svg?style=flat)](https://www.npmjs.com/package/@uiw/codemirror-theme-copilot)                                                 |
 | [`@uiw/codemirror-theme-duotone`](https://uiwjs.github.io/react-codemirror/#/theme/data/duotone/light)                   | [![npm version](https://img.shields.io/npm/v/@uiw/codemirror-theme-duotone.svg)](https://www.npmjs.com/package/@uiw/codemirror-theme-duotone) [![NPM Downloads](https://img.shields.io/npm/dm/@uiw/codemirror-theme-duotone.svg?style=flat)](https://www.npmjs.com/package/@uiw/codemirror-theme-duotone)                                                 |
 | [`@uiw/codemirror-theme-dracula`](https://uiwjs.github.io/react-codemirror/#/theme/data/dracula)                         | [![npm version](https://img.shields.io/npm/v/@uiw/codemirror-theme-dracula.svg)](https://www.npmjs.com/package/@uiw/codemirror-theme-dracula) [![NPM Downloads](https://img.shields.io/npm/dm/@uiw/codemirror-theme-dracula.svg?style=flat)](https://www.npmjs.com/package/@uiw/codemirror-theme-dracula)                                                 |
@@ -193,12 +194,12 @@ export default function App() {
 ```
 
 ## Codemirror Merge
+
 A component that highlights the changes between two versions of a file in a side-by-side view, highlighting added, modified, or deleted lines of code.
 
 ```bash
 npm install react-codemirror-merge  --save
 ```
-
 
 ```jsx
 import CodeMirrorMerge from 'react-codemirror-merge';

--- a/themes/console/README.md
+++ b/themes/console/README.md
@@ -1,0 +1,102 @@
+<!--rehype:ignore:start-->
+
+# Console Theme (dark/light)
+
+<!--rehype:ignore:end-->
+
+[![Buy me a coffee](https://img.shields.io/badge/Buy%20me%20a%20coffee-048754?logo=buymeacoffee)](https://jaywcjlove.github.io/#/sponsor)
+[![npm version](https://img.shields.io/npm/v/@uiw/codemirror-theme-console.svg)](https://www.npmjs.com/package/@uiw/codemirror-theme-console)
+
+<!--missing images-->
+
+## Motivation
+
+One of the usages for react-codemirror is a logger component, but there is no theme with the required styles for achieving the desired feature. This theme is intended to be used when you want to have plain text in a console or terminal viewer.
+
+## Install
+
+```bash
+npm install @uiw/codemirror-theme-console --save
+```
+
+```jsx
+import { consoleLight, consoleLightInit, consoleDark, consoleDarkInit } from '@uiw/codemirror-theme-console';
+// Or
+import { consoleDark, consoleDarkInit } from '@uiw/codemirror-theme-console/dark';
+import { consoleLight, consoleLightInit } from '@uiw/codemirror-theme-console/light';
+
+<CodeMirror theme={consoleLight} />
+<CodeMirror
+  theme={consoleLightInit({
+    settings: {
+      caret: '#c6c6c6',
+      fontFamily: 'monospace',
+    }
+  })}
+/>
+```
+
+## API
+
+```tsx
+import { CreateThemeOptions } from '@uiw/codemirror-themes';
+export declare const defaultSettingsConsoleLight: CreateThemeOptions['settings'];
+export declare const consoleLightInit: (options?: Partial<CreateThemeOptions>) => import('@codemirror/state').Extension;
+export declare const consoleLight: import('@codemirror/state').Extension;
+export declare const defaultSettingsConsoleDark: CreateThemeOptions['settings'];
+export declare const consoleDarkInit: (options?: Partial<CreateThemeOptions>) => import('@codemirror/state').Extension;
+export declare const consoleDark: import('@codemirror/state').Extension;
+```
+
+## Usage
+
+```jsx
+import CodeMirror from '@uiw/react-codemirror';
+import { consoleLight, consoleDark } from '@uiw/codemirror-theme-console';
+import { javascript } from '@codemirror/lang-javascript';
+
+function App() {
+  return (
+    <CodeMirror
+      value="INFO:waitress:Serving on http://0.0.0.0:5000"
+      height="200px"
+      theme={consoleLight}
+      onChange={(value, viewUpdate) => {
+        console.log('value:', value);
+      }}
+    />
+  );
+}
+export default App;
+```
+
+```js
+import { EditorView } from '@codemirror/view';
+import { EditorState } from '@codemirror/state';
+import { javascript } from '@codemirror/lang-javascript';
+import { consoleLight, consoleDark } from '@uiw/codemirror-theme-console';
+
+const state = EditorState.create({
+  doc: 'my source code',
+  extensions: [consoleDark],
+});
+
+const view = new EditorView({
+  parent: document.querySelector('#editor'),
+  state,
+});
+```
+
+## Contributors
+
+As always, thanks to our amazing contributors!
+
+<a href="https://github.com/uiwjs/react-codemirror/graphs/contributors">
+  <img src="https://uiwjs.github.io/react-codemirror/CONTRIBUTORS.svg" />
+</a>
+
+Made with [github-action-contributors](https://github.com/jaywcjlove/github-action-contributors).
+
+## License
+
+Licensed under the MIT License.

--- a/themes/console/dark.d.ts
+++ b/themes/console/dark.d.ts
@@ -1,0 +1,6 @@
+declare module '@uiw/codemirror-theme-console/dark' {
+  import { CreateThemeOptions } from '@uiw/codemirror-themes';
+  export const defaultSettingsConsoleDark: CreateThemeOptions['settings'];
+  export const consoleDarkInit: (options?: Partial<CreateThemeOptions>) => import('@codemirror/state').Extension;
+  export const consoleDark: import('@codemirror/state').Extension;
+}

--- a/themes/console/light.d.ts
+++ b/themes/console/light.d.ts
@@ -1,0 +1,6 @@
+declare module '@uiw/codemirror-theme-console/light' {
+  import { CreateThemeOptions } from '@uiw/codemirror-themes';
+  export const defaultSettingsConsoleLight: CreateThemeOptions['settings'];
+  export const consoleLightInit: (options?: Partial<CreateThemeOptions>) => import('@codemirror/state').Extension;
+  export const consoleLight: import('@codemirror/state').Extension;
+}

--- a/themes/console/package.json
+++ b/themes/console/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@uiw/codemirror-theme-console",
+  "version": "1.0.0",
+  "description": "Theme console for CodeMirror.",
+  "homepage": "https://uiwjs.github.io/react-codemirror/#/theme/data/console/light",
+  "author": "David Villamarin <dalejo_1996@hotmail.com>",
+  "license": "MIT",
+  "main": "./cjs/index.js",
+  "module": "./esm/index.js",
+  "exports": {
+    "./README.md": "./README.md",
+    ".": {
+      "import": "./esm/index.js",
+      "types": "./cjs/index.d.ts",
+      "require": "./cjs/index.js"
+    },
+    "./light": {
+      "import": "./esm/light.js",
+      "types": "./cjs/light.d.ts",
+      "require": "./cjs/light.js"
+    },
+    "./dark": {
+      "import": "./esm/dark.js",
+      "types": "./cjs/dark.d.ts",
+      "require": "./cjs/dark.js"
+    }
+  },
+  "scripts": {
+    "watch": "tsbb watch src/*.ts --use-babel",
+    "build": "tsbb build src/*.ts --use-babel"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/uiwjs/react-codemirror.git"
+  },
+  "files": [
+    "dark.d.ts",
+    "light.d.ts",
+    "src",
+    "esm",
+    "cjs"
+  ],
+  "dependencies": {
+    "@uiw/codemirror-themes": "4.21.21"
+  },
+  "keywords": [
+    "codemirror",
+    "codemirror6",
+    "theme",
+    "console",
+    "syntax",
+    "ide",
+    "code"
+  ],
+  "jest": {
+    "coverageReporters": [
+      "lcov",
+      "json-summary"
+    ]
+  }
+}

--- a/themes/console/src/dark.ts
+++ b/themes/console/src/dark.ts
@@ -1,0 +1,27 @@
+import { createTheme, CreateThemeOptions } from '@uiw/codemirror-themes';
+
+export const defaultSettingsConsoleDark: CreateThemeOptions['settings'] = {
+  background: '#000',
+  foreground: '#fff',
+  caret: '#fff',
+  selection: '#3e4865',
+  selectionMatch: '#2a3967',
+  gutterBackground: '#000',
+  gutterForeground: '#ada9a9',
+  gutterActiveForeground: '#000',
+  lineHighlight: '#828282',
+};
+
+export const consoleDarkInit = (options?: Partial<CreateThemeOptions>) => {
+  const { theme = 'dark', settings = {}, styles = [] } = options || {};
+  return createTheme({
+    theme: theme,
+    settings: {
+      ...defaultSettingsConsoleDark,
+      ...settings,
+    },
+    styles: [...styles],
+  });
+};
+
+export const consoleDark = consoleDarkInit();

--- a/themes/console/src/index.ts
+++ b/themes/console/src/index.ts
@@ -1,0 +1,2 @@
+export * from './dark';
+export * from './light';

--- a/themes/console/src/light.ts
+++ b/themes/console/src/light.ts
@@ -1,0 +1,27 @@
+import { createTheme, CreateThemeOptions } from '@uiw/codemirror-themes';
+
+export const defaultSettingsConsoleLight: CreateThemeOptions['settings'] = {
+  background: '#fff',
+  foreground: '#000',
+  caret: '#000',
+  selection: '#d6ddf2',
+  selectionMatch: '#6d85cf',
+  gutterBackground: '#fff',
+  gutterForeground: '#ada9a9',
+  gutterActiveForeground: '#000',
+  lineHighlight: '#c7c5c5',
+};
+
+export const consoleLightInit = (options?: Partial<CreateThemeOptions>) => {
+  const { theme = 'light', settings = {}, styles = [] } = options || {};
+  return createTheme({
+    theme: theme,
+    settings: {
+      ...defaultSettingsConsoleLight,
+      ...settings,
+    },
+    styles: [...styles],
+  });
+};
+
+export const consoleLight = consoleLightInit();

--- a/themes/console/tsconfig.json
+++ b/themes/console/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "./cjs",
+    "baseUrl": ".",
+    "noEmit": false
+  }
+}

--- a/www/src/router.tsx
+++ b/www/src/router.tsx
@@ -249,6 +249,28 @@ export const routes: MenuRouteObject[] = [
             ),
           },
           {
+            path: 'data/console/light',
+            label: 'Console Light',
+            element: (
+              <Preview
+                mode="light"
+                themePkg="@uiw/codemirror-theme-console"
+                path={() => import('@uiw/codemirror-theme-console/README.md')}
+              />
+            ),
+          },
+          {
+            path: 'data/console/dark',
+            label: 'Console Dark',
+            element: (
+              <Preview
+                mode="dark"
+                themePkg="@uiw/codemirror-theme-console"
+                path={() => import('@uiw/codemirror-theme-console/README.md')}
+              />
+            ),
+          },
+          {
             path: 'data/dracula',
             label: 'dracula',
             element: (


### PR DESCRIPTION
I have added the `console` theme to use the react-codemirror as a logger component in our react applications.
I can start using this theme in my project.

Images are still missing, how could I add those?

**Dark**
![image](https://github.com/uiwjs/react-codemirror/assets/77456654/e7dec367-335e-4a24-b283-f42e1709d93a)

**Light**
![image](https://github.com/uiwjs/react-codemirror/assets/77456654/46102af8-9803-42a0-8944-bd4a1a98f144)

Please review