### PR TITLE
fix: correct type of `container` returned from `useCodeMirror`

### DIFF
--- a/core/src/useCodeMirror.ts
+++ b/core/src/useCodeMirror.ts
@@ -38,7 +38,7 @@ export function useCodeMirror(props: UseCodeMirror) {
     root,
     initialState,
   } = props;
-  const [container, setContainer] = useState<HTMLDivElement>();
+  const [container, setContainer] = useState<HTMLDivElement | null>();
   const [view, setView] = useState<EditorView>();
   const [state, setState] = useState<EditorState>();
   const defaultThemeOption = EditorView.theme({
@@ -114,7 +114,7 @@ export function useCodeMirror(props: UseCodeMirror) {
     };
   }, [container, state]);
 
-  useEffect(() => setContainer(props.container!), [props.container]);
+  useEffect(() => setContainer(props.container), [props.container]);
 
   useEffect(
     () => () => {


### PR DESCRIPTION
Closes #474 

I don't know if we should merge this PR (I didn't find a better solution to avoid `null` type).