### PR TITLE
Externalize JSX runtime

### DIFF
--- a/core/.kktrc.ts
+++ b/core/.kktrc.ts
@@ -65,6 +65,18 @@ export default (conf: WebpackConfiguration, env: 'production' | 'development', o
         commonjs: 'react-dom',
         amd: 'react-dom',
       },
+      'react/jsx-runtime': {
+        root: 'ReactJSXRuntime',
+        commonjs2: 'react/jsx-runtime',
+        commonjs: 'react/jsx-runtime',
+        amd: 'react/jsx-runtime',
+      },
+      'react/jsx-dev-runtime': {
+        root: 'ReactJSXDevRuntime',
+        commonjs2: 'react/jsx-dev-runtime',
+        commonjs: 'react/jsx-dev-runtime',
+        amd: 'react/jsx-dev-runtime',
+      },
     };
   }
   return conf;


### PR DESCRIPTION
The JSX runtime is currently being bundled which is generally not supported. The JSX runtime needs to be in lockstep with the React version.

This currently breaks in React 19 because the bundled JSX runtime tries to access secret internals that have been moved.