### PR TITLE
theme: Vscode Light - lineHighlight

### DIFF
--- a/themes/vscode/src/light.ts
+++ b/themes/vscode/src/light.ts
@@ -10,7 +10,7 @@ export const defaultSettingsVscodeLight: CreateThemeOptions['settings'] = {
   caret: '#000',
   selection: '#add6ff',
   selectionMatch: '#a8ac94',
-  lineHighlight: '#f0f0f0',
+  lineHighlight: '#99999926',
   gutterBackground: '#fff',
   gutterForeground: '#237893',
   gutterActiveForeground: '#0b216f',


### PR DESCRIPTION
Changed the line highlight color in the VSCode Light theme to #99999926.
It is now the same as the original color #f0f0f0 due to the opacity, and now the selected text at the highlighted line is visible.

before
![image](https://github.com/user-attachments/assets/ded27e76-bc80-4bf2-bcff-3bffbad0080a)
after
![image](https://github.com/user-attachments/assets/35ac3dbd-5165-44dd-9bcb-69c5648f41a0)
