### PR TITLE
Implement 'exports' field in package.json for the core & basics setup packages

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -8,6 +8,10 @@
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
+  "exports": {
+    "require": "./cjs/index.js",
+    "import": "./esm/index.js"
+  },
   "scripts": {
     "bundle": "ncc build src/index.tsx --target web --filename codemirror && npm run bundle:min",
     "bundle:watch": "ncc watch src/index.tsx --target web --filename codemirror",

--- a/extensions/basic-setup/package.json
+++ b/extensions/basic-setup/package.json
@@ -8,6 +8,10 @@
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
+  "exports": {
+    "require": "./cjs/index.js",
+    "import": "./esm/index.js"
+  },
   "scripts": {
     "watch": "tsbb watch src/*.ts --use-babel",
     "build": "tsbb build src/*.ts --use-babel"


### PR DESCRIPTION
Added exports field to the core (@uiw/react-codemirror) and basic setup (@uiw/codemirror-extensions-basic-setup) package.json so Node-like environments such as the test runners can utilise the esm outputs.

Context:

Our unit tests are failing with:
```
Unrecognized extension value in extension set ([object Object]). This sometimes happens because multiple instances of @codemirror/state are loaded, breaking instanceof checks.
```

After some investigation, it looks like when this library is used in a Node environment all imports use the cjs output. `main` and `module` are already defined and work for bundlers. However, Node doesn't have support for `module` and opts to look in `exports` for entry points. Since `exports` is not defined it falls back to `main` meaning Node will use the cjs outputs of this library. Normally this is fine, but the `@codemirror` packages (i.e. @codemirror/language) in the `peerDependencies` do define `exports` so the esm outputs are used if we use any of those packages are used in our source code resulting in the error above.

We're using `@codemirror/language` to construct an extension that gets passed into `useCodeMirror`, where cjs is used but the extension uses the esm output. This results in the `instanceof` checfailingil as the esm instance is not the cjs class.

Likely related to https://github.com/uiwjs/react-codemirror/issues/680 as they're using SSR which is potentially also in a Node-like environment.

We've manually modified the package.json locally to include the `export` field asserted our tests are passing and are using the correct esm output.
