### PR TITLE
type: module in codemirror-extensions-basic-setup

### DIFF
--- a/extensions/basic-setup/package.json
+++ b/extensions/basic-setup/package.json
@@ -6,6 +6,7 @@
   "funding": "https://jaywcjlove.github.io/#/sponsor",
   "author": "kenny wong <wowohoo@qq.com>",
   "license": "MIT",
+  "type": "module",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "exports": {


### PR DESCRIPTION
I am getting errors about this package not having `type: module`, hence imports don't work. This line fixes it. Lemme know if you'd like me to do so for the other packages too