### PR TITLE
fix: Pass `diffConfig` to options in `CodeMirrorMerge` component

### DIFF
--- a/merge/src/Internal.tsx
+++ b/merge/src/Internal.tsx
@@ -24,12 +24,21 @@ export const Internal = React.forwardRef<InternalRef, CodeMirrorMergeProps>((pro
     collapseUnchanged,
     destroyRerender = true,
     renderRevertControl,
+    diffConfig,
     ...elmProps
   } = props;
   const { modified, modifiedExtension, original, originalExtension, theme, dispatch, ...otherStore } = useStore();
   const editor = useRef<HTMLDivElement>(null);
   const view = useRef<MergeView>();
-  const opts = { orientation, revertControls, highlightChanges, gutter, collapseUnchanged, renderRevertControl };
+  const opts = {
+    orientation,
+    revertControls,
+    highlightChanges,
+    gutter,
+    collapseUnchanged,
+    renderRevertControl,
+    diffConfig,
+  };
 
   useImperativeHandle(
     ref,


### PR DESCRIPTION
## Fix: `diffConfig` Prop Not Applied to `CodeMirrorMerge` Options

The `diffConfig` prop is defined in the `MergeConfig` interface but is incorrectly spread onto the `<div>` element instead of being passed to the editor options.

This prevents customization of the `diffConfig` parameter.

![image](https://github.com/user-attachments/assets/a4c539e5-1655-45c5-bd72-338b71e6194a)

This PR correctly passes the `diffConfig` prop to the mergeConfig options, enabling proper customization.


