### PR TITLE
fix(theme): correctly extend basic light theme

### DIFF
--- a/themes/basic/src/light.ts
+++ b/themes/basic/src/light.ts
@@ -74,7 +74,7 @@ export const basicLightInit = (options?: Partial<CreateThemeOptions>) => {
       ...defaultSettingsBasicLight,
       ...settings,
     },
-    styles: [...styles],
+    styles: [...basicLightStyle, ...styles],
   });
 };
 


### PR DESCRIPTION
Correctly extends the base theme for the theme `basic`.