### PR TITLE
Fix flash of content on initialization 

### DIFF
--- a/core/src/index.tsx
+++ b/core/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, forwardRef, useImperativeHandle } from 'react';
+import React, { useRef, forwardRef, useImperativeHandle, useCallback } from 'react';
 import type { EditorState, EditorStateConfig, Extension, StateField } from '@codemirror/state';
 import type { EditorView, ViewUpdate } from '@codemirror/view';
 import { type BasicSetupOptions } from '@uiw/codemirror-extensions-basic-setup';
@@ -116,9 +116,8 @@ const ReactCodeMirror = forwardRef<ReactCodeMirrorRef, ReactCodeMirrorProps>((pr
     initialState,
     ...other
   } = props;
-  const editor = useRef<HTMLDivElement>(null);
-  const { state, view, container } = useCodeMirror({
-    container: editor.current,
+  const editor = useRef<HTMLDivElement | null>(null);
+  const { state, view, container, setContainer } = useCodeMirror({
     root,
     value,
     autoFocus,
@@ -150,13 +149,23 @@ const ReactCodeMirror = forwardRef<ReactCodeMirrorRef, ReactCodeMirrorProps>((pr
     view,
   ]);
 
+  const setEditorRef = useCallback(
+    (el: HTMLDivElement) => {
+      editor.current = el;
+      setContainer(el);
+    },
+    [setContainer],
+  );
+
   // check type of value
   if (typeof value !== 'string') {
     throw new Error(`value must be typeof string but got ${typeof value}`);
   }
 
   const defaultClassNames = typeof theme === 'string' ? `cm-theme-${theme}` : 'cm-theme';
-  return <div ref={editor} className={`${defaultClassNames}${className ? ` ${className}` : ''}`} {...other}></div>;
+  return (
+    <div ref={setEditorRef} className={`${defaultClassNames}${className ? ` ${className}` : ''}`} {...other}></div>
+  );
 });
 
 ReactCodeMirror.displayName = 'CodeMirror';

--- a/core/src/useCodeMirror.ts
+++ b/core/src/useCodeMirror.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { Annotation, EditorState, StateEffect, type Extension } from '@codemirror/state';
 import { EditorView, type ViewUpdate } from '@codemirror/view';
 import { getDefaultExtensions } from './getDefaultExtensions';
@@ -85,7 +85,7 @@ export function useCodeMirror(props: UseCodeMirror) {
   }
   getExtensions = getExtensions.concat(extensions);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (container && !state) {
       const config = {
         doc: value,
@@ -114,7 +114,11 @@ export function useCodeMirror(props: UseCodeMirror) {
     };
   }, [container, state]);
 
-  useEffect(() => setContainer(props.container), [props.container]);
+  useEffect(() => {
+    if (props.container) {
+      setContainer(props.container);
+    }
+  }, [props.container]);
 
   useEffect(
     () => () => {

--- a/www/src/pages/home/Example.tsx
+++ b/www/src/pages/home/Example.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { color } from '@uiw/codemirror-extensions-color';
 import DocumentStr from '@uiw/react-codemirror/README.md';
@@ -10,6 +10,7 @@ import { langs } from '@uiw/codemirror-extensions-langs';
 import { Select } from './Select';
 import { Options } from '../extensions/basic-setup/example';
 import { useTheme } from '../../utils/useTheme';
+import javascriptExample from 'code-example/txt/sample.javascript.txt';
 
 const themeOptions = ['dark', 'light']
   .concat(Object.keys(alls))
@@ -61,7 +62,7 @@ export default function Example() {
   const [autofocus, setAutofocus] = useState(false);
   const [editable, setEditable] = useState(true);
   const { theme, setTheme } = useTheme();
-  const [code, setCode] = useState('');
+  const [code, setCode] = useState(javascriptExample);
   const [extensions, setExtensions] = useState<Extension[]>();
   const [height, setHeight] = useState('500px');
   const [basicSetup, setBasicSetup] = useState<BasicSetupOptions>({
@@ -91,9 +92,7 @@ export default function Example() {
       }
     } catch (error) {}
   }
-  useEffect(() => {
-    handleLangChange('javascript');
-  }, []);
+
   return (
     <Warpper className="wmde-markdown-var">
       <CodemirrorWarpper>


### PR DESCRIPTION
Does two things to eliminate the flash, when using the `ReactCodeMirror` component:
1. Eliminate one initial re-render from calling `setContainer` in an effect when the `container` prop changes
  - previously, this resulted in `setContainer(null)` -> re-render -> `setContainer(el)` -> re-render -> [now component can initialize]
  - now, the first effect invocation no-ops, since the ref value is not truthy, then the second time no state is updated, since `props.container` is referentially equal to `container`, set by the ref callback when the `div` mounted
2. Eliminate one paint by running initialization in a layout effect, which forces the second re-render to occur synchronously before paint
 
So the new set of render cycles on mount is:
mount -> `setContainer` in callback ref -> re-render -> layout effect to initialize editor state -> re-render -> paint

It won't eliminate flashing when users choose to use `useCodeMirror` directly, unless they are also calling `setContainer` in a callback ref on their parent element. 

Ideally, I think `useCodeMirror` would not take a container prop at all, and would instead do all of the state/view initialization logic in `setContainer`, which would be a callback ref. However, this is a breaking change, and I don't want to remove all of the synchronization logic in effects which enables passing a different `container`.