### PR TITLE
fix: Set correct module type in basic package

### DIFF
--- a/extensions/basic-setup/package.json
+++ b/extensions/basic-setup/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "watch": "tsbb watch src/*.ts --use-babel",
-    "build": "tsbb build src/*.ts --use-babel"
+    "build": "tsbb build src/*.ts --use-babel && npm run setmodule",
+    "setmodule": "echo '{\"type\":\"module\"}' > esm/package.json && echo '{\"type\":\"commonjs\"}' > cjs/package.json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a fix/workaround for the CommonJS/esm issue.

The root cause was adding the `exports` fields in `package.json`. Before it was introduced, Node.js would pick up what is defined in the `main` field (cjs)  and bundlers used the `module` field (esm). When the `exports` field was introduced, Node.js started picking up the esm version too, but is nagging about no `types` field in `package.json`. After the `types` field was added, commonjs in bundlers is not working anymore because `package.json` says that all `.js` files in the package are ESM.

Possibilities:
- Remove `exports` and `type` fields in package.json 
- Add 2 new `package.json` files and define the type correctly for the generated files. (What this PR does)

Fixes #724 
Fixes #719 

Ref #710 
Ref #680 