### PR TITLE
Fix ESM import in core package by adding .babelrc and babel-plugin-add-import-extension

### DIFF
--- a/core/.babelrc
+++ b/core/.babelrc
@@ -1,0 +1,22 @@
+{
+    "env": {
+        "cjs": {
+            "presets": [
+                "@babel/preset-typescript"
+            ]
+        },
+        "esm": {
+            "presets": [
+                "@babel/preset-env"
+            ],
+            "plugins": [
+                [
+                    "babel-plugin-add-import-extension",
+                    {
+                        "extension": "js"
+                    }
+                ]
+            ]
+        }
+    }
+}

--- a/core/package.json
+++ b/core/package.json
@@ -65,5 +65,8 @@
       "lcov",
       "json-summary"
     ]
+  },
+  "devDependencies": {
+    "babel-plugin-add-import-extension": "^1.6.0"
   }
 }


### PR DESCRIPTION
This fixes issues from https://github.com/uiwjs/react-codemirror/issues/731.

Here is the codesandbox that implements this https://codesandbox.io/p/github/Shellishack/webpack-esm-sandbox/fork-fix. After adding the babel plugin, core builds for ESM contains ".js" suffix in import clauses. So webpack no longer complains things like:
```
ERROR in ./node_modules/@uiw/react-codemirror/esm/index.js 5:0-48
Module not found: Error: Can't resolve './useCodeMirror' in 'C:\GitHub\pulse-editor-code-view\node_modules\@uiw\react-codemirror\esm'
Did you mean 'useCodeMirror.js'?
``` 

This might be a fix only for Webpack (I am only familiar with Webpack). May need more testing for Vite, etc.

I am sure if adding a babel plugin in this case would be the most appropriate solution, since it was the building tool that did not include file extensions in imports. Is it a behavior from tsbb causing this issue? LMK what you think.