### PR TITLE
Add External annotation to the public API

### DIFF
--- a/core/src/useCodeMirror.ts
+++ b/core/src/useCodeMirror.ts
@@ -6,7 +6,7 @@ import { getStatistics } from './utils';
 import { type ReactCodeMirrorProps } from '.';
 import { TimeoutLatch, getScheduler } from './timeoutLatch';
 
-const External = Annotation.define<boolean>();
+export const ExternalChange = Annotation.define<boolean>();
 const TYPING_TIMOUT = 200; // ms
 
 export interface UseCodeMirror extends ReactCodeMirrorProps {
@@ -64,7 +64,7 @@ export function useCodeMirror(props: UseCodeMirror) {
       typeof onChange === 'function' &&
       // Fix echoing of the remote changes:
       // If transaction is market as remote we don't have to call `onChange` handler again
-      !vu.transactions.some((tr) => tr.annotation(External))
+      !vu.transactions.some((tr) => tr.annotation(ExternalChange))
     ) {
       if (typingLatch.current) {
         typingLatch.current.reset();
@@ -193,7 +193,7 @@ export function useCodeMirror(props: UseCodeMirror) {
         if (view && value !== view.state.doc.toString()) {
           view.dispatch({
             changes: { from: 0, to: view.state.doc.toString().length, insert: value || '' },
-            annotations: [External.of(true)],
+            annotations: [ExternalChange.of(true)],
           });
         }
       };


### PR DESCRIPTION
Consider an example:
an app has table of content (ToC) and an editor. Clicking on a table of content item selects and scrolls into view the clicked section.
moving cursor to another section with arrow keys highlights corresponding ToC item.
This requires sending selection changes to CM6 and listening for selection changes.
When ToC is clicked the app triggers an update, and immediately receives the onChange with the same update.
Distinguishing between changes triggered by user and by app itself can be done on the app side, but it's a lot of unnecessary complex logic.

Or, if the app had access to the External annotation it could simply tell useCodeMirror to ignore the change.

This is the motivation behind this PR.