### PR TITLE
fix(extensions): typing issue string instead of an union type

### DIFF
--- a/extensions/langs/src/index.ts
+++ b/extensions/langs/src/index.ts
@@ -107,7 +107,7 @@ import { nix } from '@replit/codemirror-lang-nix';
 import { svelte } from '@replit/codemirror-lang-svelte';
 import { solidity } from '@replit/codemirror-lang-solidity';
 
-export const langs: Record<string, () => LanguageSupport | StreamLanguage<unknown>> = {
+export const langs = {
   '1': () => StreamLanguage.define(troff),
   '2': () => StreamLanguage.define(troff),
   '3': () => StreamLanguage.define(troff),
@@ -332,7 +332,7 @@ export const langs: Record<string, () => LanguageSupport | StreamLanguage<unknow
   yml: () => yaml(),
   ys: () => StreamLanguage.define(yacas),
   z80: () => StreamLanguage.define(z80),
-};
+} satisfies Record<string, () => LanguageSupport | StreamLanguage<unknown>>;
 
 export const langNames = Object.keys(langs) as LanguageName[];
 


### PR DESCRIPTION
we use the the typing of languageName which was break in the last version from union type to string

With sastifiy i still check that my value have the right type but keep the right typing for my users.

https://github.com/scaleway/ultraviolet/blob/main/packages/plus/src/components/CodeEditor/CodeEditor.tsx#L110
<img width="576" height="440" alt="Capture d’écran 2025-09-18 à 16 37 33" src="https://github.com/user-attachments/assets/2004f20d-42c8-4366-b598-81b1d29ef651" />


Actually 
<img width="647" height="193" alt="Capture d’écran 2025-09-18 à 16 41 31" src="https://github.com/user-attachments/assets/6428fa70-f8c6-4ef8-9f62-1a02eda9e7ad" />

@jaywcjlove 


