### PR TITLE
fix: workspace packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "clean": "lerna clean --yes"
   },
   "workspaces": [
-    "themes/**",
-    "extensions/**",
+    "themes/*",
+    "extensions/*",
     "core",
     "merge",
     "www"


### PR DESCRIPTION
I noticed the build failed on https://github.com/uiwjs/react-codemirror/pull/763, sorry about that! I believe that's because it was trying to include the stub `package.json` files as workspace packages, and was failing due to them being named after their directories. This should fix things by only considering direct descendants of the `themes` and `extensions` directories for workspace packages.