### PR TITLE
fix: prevent memory leak from theme recreation

### DIFF
--- a/core/src/theme/dimensionTheme.ts
+++ b/core/src/theme/dimensionTheme.ts
@@ -1,0 +1,42 @@
+import { EditorView } from '@codemirror/view';
+import type { Extension } from '@codemirror/state';
+
+export const scrollerTheme = EditorView.theme({
+  '& .cm-scroller': {
+    height: '100% !important',
+  },
+});
+
+let lastDimensionKey: string | null = null;
+let lastDimensionTheme: Extension | null = null;
+
+export function getDimensionTheme(
+  height: string | null,
+  minHeight: string | null,
+  maxHeight: string | null,
+  width: string | null,
+  minWidth: string | null,
+  maxWidth: string | null,
+): Extension | null {
+  if (!height && !minHeight && !maxHeight && !width && !minWidth && !maxWidth) {
+    return null;
+  }
+
+  const cacheKey = JSON.stringify({ height, minHeight, maxHeight, width, minWidth, maxWidth });
+  if (cacheKey === lastDimensionKey) {
+    return lastDimensionTheme;
+  }
+
+  lastDimensionKey = cacheKey;
+  lastDimensionTheme = EditorView.theme({
+    '&': {
+      height,
+      minHeight,
+      maxHeight,
+      width,
+      minWidth,
+      maxWidth,
+    },
+  });
+  return lastDimensionTheme;
+}

--- a/core/src/useCodeMirror.ts
+++ b/core/src/useCodeMirror.ts
@@ -5,6 +5,7 @@ import { getDefaultExtensions } from './getDefaultExtensions';
 import { getStatistics } from './utils';
 import { type ReactCodeMirrorProps } from '.';
 import { TimeoutLatch, getScheduler } from './timeoutLatch';
+import { scrollerTheme, getDimensionTheme } from './theme/dimensionTheme';
 
 export const ExternalChange = Annotation.define<boolean>();
 const TYPING_TIMOUT = 200; // ms
@@ -45,19 +46,7 @@ export function useCodeMirror(props: UseCodeMirror) {
   const [state, setState] = useState<EditorState>();
   const typingLatch = useState<{ current: TimeoutLatch | null }>(() => ({ current: null }))[0];
   const pendingUpdate = useState<{ current: (() => void) | null }>(() => ({ current: null }))[0];
-  const defaultThemeOption = EditorView.theme({
-    '&': {
-      height,
-      minHeight,
-      maxHeight,
-      width,
-      minWidth,
-      maxWidth,
-    },
-    '& .cm-scroller': {
-      height: '100% !important',
-    },
-  });
+  const defaultThemeOption = getDimensionTheme(height, minHeight, maxHeight, width, minWidth, maxWidth);
   const updateListener = EditorView.updateListener.of((vu: ViewUpdate) => {
     if (
       vu.docChanged &&
@@ -96,7 +85,12 @@ export function useCodeMirror(props: UseCodeMirror) {
     basicSetup: defaultBasicSetup,
   });
 
-  let getExtensions = [updateListener, defaultThemeOption, ...defaultExtensions];
+  let getExtensions = [
+    updateListener,
+    ...(defaultThemeOption ? [defaultThemeOption] : []),
+    scrollerTheme,
+    ...defaultExtensions,
+  ];
 
   if (onUpdate && typeof onUpdate === 'function') {
     getExtensions.push(EditorView.updateListener.of(onUpdate));


### PR DESCRIPTION
There's a memory leak happening every time `CodeMirror` remounts; it duplicates styles because `defaultThemeOption` is recreated on every mount. It was fixed by adding a static reference to the extension with the `.cm-scroller` rule, and caching and reusing the other `defaultThemeOption ` part that sets dimensions. Basically, when reused from the cache with the same widths and heights, we do not recreate the extension.
Below is the example without changes after several remounts:

<img width="686" height="988" alt="image" src="https://github.com/user-attachments/assets/6e1c3773-e142-4f49-b26c-586c4cfb95ea" />

However, there's still a thing that if you implement logic where you change dimensions (let's say only height) programmatically, they will not be replaced in the CSS but `CodeMirror` will just create an extra overriding class:

<img width="687" height="305" alt="image" src="https://github.com/user-attachments/assets/2ffce7c0-04ae-435b-9480-9d3c2fd5cce4" />

